### PR TITLE
Initial OOPS changes to work with Python 2 and 3

### DIFF
--- a/oops/backplane.py
+++ b/oops/backplane.py
@@ -181,8 +181,8 @@ class Backplane(object):
         if type(event_key) == str:
             event_key = (event_key.upper(),)
 
-        elif isinstance(event_key, basestring):
-            event_key = (str(event_key).upper(),)
+        # elif isinstance(event_key, basestring):
+        #     event_key = (str(event_key).upper(),)
 
         elif type(event_key) == tuple:
             items = []
@@ -4038,10 +4038,10 @@ def exercise_backplanes(filespec, printing, logging, saving, undersample=16,
 # Used for testing other images
 #     test = bp.longitude('enceladus')
 #     show_info('Enceladus longitude (deg)', test * constants.DPR)
-# 
+#
 #     test = bp.sub_observer_longitude('enceladus')
 #     show_info('Enceladus sub-observer longitude (deg)', test * constants.DPR)
-# 
+#
 #     test = bp.sub_solar_longitude('enceladus')
 #     show_info('Enceladus sub-solar longitude (deg)', test * constants.DPR)
 

--- a/oops/body.py
+++ b/oops/body.py
@@ -603,7 +603,7 @@ class Body(object):
     @staticmethod
     def reset_registry():
         """Initialize the registry.
-    
+
         It is not generally necessary to call this function, but it can be used
         to reset the registry for purposes of debugging.
         """
@@ -762,9 +762,9 @@ def _define_mars(start_time, stop_time, asof=None):
 # Jupiter System
 ################################################################################
 
-JUPITER_CLASSICAL = range(501,505)
-JUPITER_REGULAR   = [505] + range(514,517)
-JUPITER_IRREGULAR = range(506,514) + range(517,559) + [554] + \
+JUPITER_CLASSICAL = list(range(501,505))
+JUPITER_REGULAR   = [505] + list(range(514,517))
+JUPITER_IRREGULAR = list(range(506,514)) + list(range(517,559)) + [554] + \
                     [55060, 55061, 55062, 55064, 55065, 55066, 55068, 55070,
                      55071, 55074]
 JUPITER_MOONS_LOADED = []
@@ -825,11 +825,11 @@ def _define_jupiter(start_time, stop_time, asof=None, irregulars=False):
 # Saturn System
 ################################################################################
 
-SATURN_CLASSICAL_INNER = range(601,607)     # Mimas through Titan orbit Saturn
-SATURN_CLASSICAL_OUTER = range(607,609)     # Hyperion, Iapetus orbit barycenter
-SATURN_CLASSICAL_IRREG = [609]              # Phoebe
-SATURN_REGULAR   = range(610,619) + range(632,636) + [649,653]
-SATURN_IRREGULAR = (range(619,632) + range(636,649) + range(650,653) +
+SATURN_CLASSICAL_INNER = list(range(601,607))     # Mimas through Titan orbit Saturn
+SATURN_CLASSICAL_OUTER = list(range(607,609))     # Hyperion, Iapetus orbit barycenter
+SATURN_CLASSICAL_IRREG = [609]                    # Phoebe
+SATURN_REGULAR   = list(range(610,619)) + list(range(632,636)) + [649,653]
+SATURN_IRREGULAR = (list(range(619,632)) + list(range(636,649)) + list(range(650,653)) +
                     [65035, 65040, 65041, 65045, 65048, 65050, 65056])
 SATURN_MOONS_LOADED = []
 
@@ -855,7 +855,7 @@ def _define_saturn(start_time, stop_time, asof=None, irregulars=False):
         SATURN_MOONS_LOADED += SATURN_IRREGULAR
 
     names = spicedb.furnish_spk(SATURN_MOONS_LOADED,
-                                time=(start_time, stop_time), 
+                                time=(start_time, stop_time),
                                 asof=asof)
 
     # Saturn and the Saturn barycenter orbit the SSB
@@ -924,9 +924,9 @@ def _define_saturn(start_time, stop_time, asof=None, irregulars=False):
 # Uranus System
 ################################################################################
 
-URANUS_CLASSICAL  = range(701,706)
-URANUS_INNER      = range(706,716) + [725,726,727]
-URANUS_IRREGULAR  = range(716,726)
+URANUS_CLASSICAL  = list(range(701,706))
+URANUS_INNER      = list(range(706,716)) + [725,726,727]
+URANUS_IRREGULAR  = list(range(716,726))
 URANUS_MOONS_LOADED = []
 
 URANUS_EPSILON_LIMIT = 51604.
@@ -1057,8 +1057,8 @@ def _define_uranus(start_time, stop_time, asof=None, irregulars=False):
 
 NEPTUNE_CLASSICAL_INNER = [801]             # Triton
 NEPTUNE_CLASSICAL_OUTER = [802]             # Nereid orbits barycenter
-NEPTUNE_REGULAR   = range(803,809)
-NEPTUNE_IRREGULAR = range(809,814)
+NEPTUNE_REGULAR   = list(range(803,809))
+NEPTUNE_IRREGULAR = list(range(809,814))
 NEPTUNE_MOONS_LOADED = []
 
 NEPTUNE_ADAMS_LIMIT = 62940.
@@ -1128,7 +1128,7 @@ def _define_neptune(start_time, stop_time, asof=None, irregulars=False):
 ################################################################################
 
 CHARON        = [901]
-PLUTO_REGULAR = range(902,906)
+PLUTO_REGULAR = list(range(902,906))
 PLUTO_MOONS_LOADED = []
 
 PLUTO_RADIUS = 19591.
@@ -1238,8 +1238,8 @@ def define_bodies(spice_ids, parent, barycenter, keywords):
         Path.STANDARD_PATHS.add(body.path.path_id)
         Frame.STANDARD_FRAMES.add(body.frame.frame_id)
 
-    keys = Body.BODY_REGISTRY.keys()
-    keys.sort()
+    # keys = Body.BODY_REGISTRY.keys()
+    # keys.sort()
 
 def define_ring(parent_name, ring_name, radii, keywords, retrograde=False,
                 barycenter_name=None, pole=None):
@@ -1258,7 +1258,7 @@ def define_ring(parent_name, ring_name, radii, keywords, retrograde=False,
                         attribute of the body will be set to this value; if
                         None, then the radius attribute of the body will be set
                         to zero.
-        keywords        the list of keywords under which this surface is to be 
+        keywords        the list of keywords under which this surface is to be
                         registered. Every ring is also registered under its own
                         name and under the keyword "RING".
         retrograde      True if the ring is retrograde relative to the central

--- a/oops/event.py
+++ b/oops/event.py
@@ -349,7 +349,7 @@ class Event(object):
 
     ############################################################################
     # Special properties: Photon arrival vectors
-    # 
+    #
     # These values are cached for repeated use.
     #
     # Upon setting any of these parameters, the immediate value is saved and at
@@ -369,7 +369,7 @@ class Event(object):
     @arr.setter
     def arr(self, value):
         if (self.__arr_ is not None) or (self.__arr_ap_ is not None):
-            raise ValueError('arriving photons were already defined in ' + 
+            raise ValueError('arriving photons were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -401,7 +401,7 @@ class Event(object):
             return
 
         if (self.__arr_ap_ is not None) or (self.__arr_ is not None):
-            raise ValueError('arriving photons were already defined in ' + 
+            raise ValueError('arriving photons were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -462,7 +462,7 @@ class Event(object):
     @arr_lt.setter
     def arr_lt(self, value):
         if self.__arr_lt_ is not None:
-            raise ValueError('arriving photons were already defined in ' + 
+            raise ValueError('arriving photons were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -478,7 +478,7 @@ class Event(object):
 
     ############################################################################
     # Special properties: Photon arrival vectors, reversed
-    # 
+    #
     # These values are cached for repeated use.
     #
     # Upon setting any of these parameters, the immediate value is saved and at
@@ -560,7 +560,7 @@ class Event(object):
 
     ############################################################################
     # Special properties: Photon departure vectors
-    # 
+    #
     # These values are cached for repeated use.
     #
     # Upon setting any of these parameters, the immediate value is saved and at
@@ -580,7 +580,7 @@ class Event(object):
     @dep.setter
     def dep(self, value):
         if (self.__dep_ is not None) or (self.__dep_ap_ is not None):
-            raise ValueError('departing photons were already defined in ' + 
+            raise ValueError('departing photons were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -610,7 +610,7 @@ class Event(object):
         if ABERRATION.old: return self.__dep_
 
         if (self.__dep_ap_ is not None) or (self.__dep_ is not None):
-            raise ValueError('departing photons were already defined in ' + 
+            raise ValueError('departing photons were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -671,7 +671,7 @@ class Event(object):
     @dep_lt.setter
     def dep_lt(self, value):
         if self.__dep_lt_ is not None:
-            raise ValueError('departing photons were already defined in ' + 
+            raise ValueError('departing photons were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -696,7 +696,7 @@ class Event(object):
     @perp.setter
     def perp(self, value):
         if self.__perp_ is not None:
-            raise ValueError('perpendiculars were already defined in ' + 
+            raise ValueError('perpendiculars were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -720,7 +720,7 @@ class Event(object):
     @vflat.setter
     def vflat(self, value):
         if self.__vflat_ is not None:
-            raise ValueError('surface velocities were already defined in ' + 
+            raise ValueError('surface velocities were already defined in ' +
                              str(self))
 
         # Raise a ValueError if the shape is incompatible
@@ -777,7 +777,7 @@ class Event(object):
                      self.__origin_.path_id, ', ',
                      self.__frame_.frame_id]
 
-        keys = self.__subfields_.keys()
+        keys = list(self.__subfields_.keys())
         keys.sort()
         for key in keys:
             str_list += ['; ', key]

--- a/oops/fittable.py
+++ b/oops/fittable.py
@@ -31,7 +31,7 @@ class Fittable(object):
         """
 
         key = tuple(params)
-        if self.cache.has_key(key):
+        if key in self.cache:
             return self.cache[key]
 
         result = self.set_params_new(params)

--- a/oops/frame_/poleframe.py
+++ b/oops/frame_/poleframe.py
@@ -167,7 +167,7 @@ class PoleFrame(Frame):
 
             # Trim the cache, removing the values used least recently
             if len(self.cache) >= self.cache_size:
-                all_keys = self.cache.values()
+                all_keys = list(self.cache.values())
                 all_keys.sort()
                 for (_, old_key, _) in all_keys[:self.trim_size]:
                     del self.cache[old_key]

--- a/spicedb.py
+++ b/spicedb.py
@@ -166,27 +166,32 @@ class KernelInfo(object):
         if self.load_priority > other.load_priority: return +1
 
         # Compare release dates
-        if self.release_date < other.release_date: return -1
-        if self.release_date > other.release_date: return +1
+        if self.release_date is not None and other.release_date is not None:
+            if self.release_date < other.release_date: return -1
+            if self.release_date > other.release_date: return +1
 
         # Group names alphabetically
         if self.kernel_name < other.kernel_name: return -1
         if self.kernel_name > other.kernel_name: return +1
 
         # Earlier versions go first
-        if self.kernel_version < other.kernel_version: return -1
-        if self.kernel_version > other.kernel_version: return +1
+        if self.kernel_version is not None and other.kernel_version is not None:
+            if self.kernel_version < other.kernel_version: return -1
+            if self.kernel_version > other.kernel_version: return +1
 
         # Earlier file numbers go first
-        if self.file_no < other.file_no: return -1
-        if self.file_no > other.file_no: return +1
+        if self.file_no is not None and other.file_no is not None:
+            if self.file_no < other.file_no: return -1
+            if self.file_no > other.file_no: return +1
 
         # Earlier end dates, later starts go first for better chance of override
-        if self.stop_time < other.stop_time: return -1
-        if self.stop_time > other.stop_time: return +1
+        if self.stop_time is not None and other.stop_time is not None:
+            if self.stop_time < other.stop_time: return -1
+            if self.stop_time > other.stop_time: return +1
 
-        if self.start_time > other.start_time: return -1
-        if self.start_time < other.start_time: return +1
+        if self.start_time is not None and other.start_time is not None:
+            if self.start_time > other.start_time: return -1
+            if self.start_time < other.start_time: return +1
 
         # Organize by file name if appropriate
         if self.filespec < other.filespec: return -1
@@ -1401,9 +1406,9 @@ def furnish_kernels(kernel_list, fast=True):
             # Save the info for each furnished file
             basename = os.path.basename(abspath)
             if basename in FURNISHED_INFO:
-                FURNISHED_INFO[basename].add(kernel)
+                FURNISHED_INFO[basename].append(kernel)
             else:
-                FURNISHED_INFO[basename] = set([kernel])
+                FURNISHED_INFO[basename] = [kernel]
 
     # Furnish the kernel files...
     if DEBUG:
@@ -1438,7 +1443,7 @@ def furnish_kernels(kernel_list, fast=True):
             furnished_names.append(name)
 
     # Append file number ranges into the names in the list returned
-    for (name,filenos) in fileno_dict.iteritems():
+    for (name,filenos) in fileno_dict.items():
         k = name_list.index(name)
         name_list[k] = name + _fileno_str(filenos)
 
@@ -3096,7 +3101,7 @@ class test_spicedb(unittest.TestCase):
 #         unload_by_type()
 #         kernels = furnish_cassini_kernels('2010-01-01', '2010-04-01',
 #                                           instrument='ISS', asof='2014-03-10')
-# 
+#
 #         self.assertIn('NAIF-LSK-0010', kernels[0:1])
 #         self.assertIn('CAS-SCLK-00171', kernels[1:2])
 #         self.assertIn('CAS-FK-V04', kernels[2:4])
@@ -3112,18 +3117,18 @@ class test_spicedb(unittest.TestCase):
 #         self.assertIn('CAS-SPK-RECONSTRUCTED-V01[90-94]', kernels[12:13])
 #         self.assertIn('DE430', kernels[13:14])
 #         self.assertIn('CAS-CK-RECONSTRUCTED-V01[438-456]', kernels[-1:])
-# 
+#
 #         self.assertEqual(FURNISHED_NAMES['LSK'], ['NAIF-LSK-0010'])
 #         self.assertEqual(FURNISHED_NAMES['SCLK'], ['CAS-SCLK-00171'])
 #         self.assertEqual(FURNISHED_NAMES['FK'], ['CAS-FK-V04'])
 #         self.assertEqual(FURNISHED_NAMES['IK'], ['CAS-IK-ISS-V10'])
-# 
+#
 #         self.assertIn('CAS-FK-ROCKS-V18', FURNISHED_NAMES['PCK'])
 #         self.assertIn('CAS-PCK-ROCKS-2011-01-21', FURNISHED_NAMES['PCK'])
 #         self.assertIn('CAS-PCK-2014-02-19', FURNISHED_NAMES['PCK'])
 #         self.assertIn('NAIF-PCK-00010-EDIT-V01', FURNISHED_NAMES['PCK'])
 #         self.assertEqual(len(FURNISHED_ABSPATHS['PCK']), 4)
-# 
+#
 #         self.assertIn('SAT357', FURNISHED_NAMES['SPK'][:4])
 #         self.assertIn('SAT360', FURNISHED_NAMES['SPK'][:4])
 #         self.assertIn('SAT362', FURNISHED_NAMES['SPK'][:4])
@@ -3133,7 +3138,7 @@ class test_spicedb(unittest.TestCase):
 #         self.assertEqual(FURNISHED_FILENOS['CAS-SPK-RECONSTRUCTED-V01'],
 #                          range(90,95))
 #         self.assertEqual(len(FURNISHED_ABSPATHS['SPK']), 5 + 5)
-# 
+#
 #         self.assertEqual(FURNISHED_NAMES['CK'], ['CAS-CK-PREDICTED-V01',
 #                                                  'CAS-CK-RECONSTRUCTED-V01'])
 #         self.assertEqual(FURNISHED_FILENOS['CAS-CK-PREDICTED-V01'],
@@ -3141,11 +3146,11 @@ class test_spicedb(unittest.TestCase):
 #         self.assertEqual(FURNISHED_FILENOS['CAS-CK-RECONSTRUCTED-V01'],
 #                          range(438,457))
 #         self.assertEqual(len(FURNISHED_ABSPATHS['CK']), 457 - 438 + 62 - 59)
-# 
+#
 #         ########
 #         kernels1 = furnish_cassini_kernels('2010-03-01', '2010-06-01',
 #                                           instrument='VIMS', asof='2014-03-10')
-# 
+#
 #         self.assertIn('NAIF-LSK-0010', kernels1[0:1])
 #         self.assertIn('CAS-SCLK-00171', kernels1[1:2])
 #         self.assertIn('CAS-FK-V04', kernels1[2:4])
@@ -3161,19 +3166,19 @@ class test_spicedb(unittest.TestCase):
 #         self.assertIn('CAS-SPK-RECONSTRUCTED-V01[93-97]', kernels1[12:13])
 #         self.assertIn('DE430', kernels1[13:14])
 #         self.assertIn('CAS-CK-RECONSTRUCTED-V01[450-468]', kernels1[-1:])
-# 
+#
 #         self.assertEqual(FURNISHED_NAMES['LSK'], ['NAIF-LSK-0010'])
 #         self.assertEqual(FURNISHED_NAMES['SCLK'], ['CAS-SCLK-00171'])
 #         self.assertEqual(FURNISHED_NAMES['FK'], ['CAS-FK-V04'])
 #         self.assertEqual(FURNISHED_NAMES['IK'], ['CAS-IK-ISS-V10',
 #                                                  'CAS-IK-VIMS-V06'])
-# 
+#
 #         self.assertIn('CAS-FK-ROCKS-V18', FURNISHED_NAMES['PCK'])
 #         self.assertIn('CAS-PCK-ROCKS-2011-01-21', FURNISHED_NAMES['PCK'])
 #         self.assertIn('CAS-PCK-2014-02-19', FURNISHED_NAMES['PCK'])
 #         self.assertIn('NAIF-PCK-00010-EDIT-V01', FURNISHED_NAMES['PCK'])
 #         self.assertEqual(len(FURNISHED_ABSPATHS['PCK']), 4)
-# 
+#
 #         self.assertIn('SAT357', FURNISHED_NAMES['SPK'][:4])
 #         self.assertIn('SAT360', FURNISHED_NAMES['SPK'][:4])
 #         self.assertIn('SAT362', FURNISHED_NAMES['SPK'][:4])
@@ -3183,7 +3188,7 @@ class test_spicedb(unittest.TestCase):
 #         self.assertEqual(FURNISHED_FILENOS['CAS-SPK-RECONSTRUCTED-V01'],
 #                          range(90,98))
 #         self.assertEqual(len(FURNISHED_ABSPATHS['SPK']), 8 + 5)
-# 
+#
 #         self.assertEqual(FURNISHED_NAMES['CK'], ['CAS-CK-PREDICTED-V01',
 #                                                  'CAS-CK-RECONSTRUCTED-V01'])
 #         self.assertEqual(FURNISHED_FILENOS['CAS-CK-PREDICTED-V01'],
@@ -3192,45 +3197,45 @@ class test_spicedb(unittest.TestCase):
 #                          range(438,469))
 #         self.assertEqual(len(FURNISHED_ABSPATHS['CK']), 469 - 438 + 64 - 59)
 #         # SPK and CK file_no lists get merged
-# 
+#
 #         ########
 #         self.assertEqual(furnished_names('CK'),
 #                          ['CAS-CK-PREDICTED-V01[59-63]',
 #                           'CAS-CK-RECONSTRUCTED-V01[438-468]'])
-# 
+#
 #         unload_by_name('CAS-CK-RECONSTRUCTED-V01[440]')
-# 
+#
 #         self.assertEqual(furnished_names('CK'),
 #                          ['CAS-CK-PREDICTED-V01[59-63]',
 #                           'CAS-CK-RECONSTRUCTED-V01[438,439,441-468]'])
 #         self.assertEqual(FURNISHED_FILENOS['CAS-CK-RECONSTRUCTED-V01'],
 #                          [438,439] + range(441,469))
-# 
+#
 #         unload_by_name('CAS-CK-RECONSTRUCTED-V01[1-438]')
-# 
+#
 #         self.assertEqual(furnished_names('CK'),
 #                          ['CAS-CK-PREDICTED-V01[59-63]',
 #                           'CAS-CK-RECONSTRUCTED-V01[439,441-468]'])
 #         self.assertEqual(FURNISHED_FILENOS['CAS-CK-RECONSTRUCTED-V01'],
 #                          [439] + range(441,469))
-# 
+#
 #         unload_by_name('CAS-CK-RECONSTRUCTED-V01[439,442-465]')
-# 
+#
 #         self.assertEqual(furnished_names('CK'),
 #                          ['CAS-CK-PREDICTED-V01[59-63]',
 #                           'CAS-CK-RECONSTRUCTED-V01[441,466-468]'])
 #         self.assertEqual(FURNISHED_FILENOS['CAS-CK-RECONSTRUCTED-V01'],
 #                          [441] + range(466,469))
-# 
+#
 #         unload_by_name('CAS-CK-RECONSTRUCTED-V01[441-468]')
-# 
+#
 #         self.assertEqual(furnished_names('CK'), ['CAS-CK-PREDICTED-V01[59-63]'])
 #         self.assertNotIn('CAS-CK-RECONSTRUCTED-V01', FURNISHED_FILENOS)
-# 
+#
 #         self.assertEqual(furnished_names('SPK'),
 #                          ['SAT357', 'SAT360', 'SAT362', 'SAT363',
 #                           'CAS-SPK-RECONSTRUCTED-V01[90-97]', 'DE430'])
-# 
+#
 #         self.assertEqual(furnished_names(['IK','FK','LSK','SCLK']),
 #                          ['CAS-IK-ISS-V10', 'CAS-IK-VIMS-V06',
 #                           'CAS-FK-V04', 'NAIF-LSK-0010', 'CAS-SCLK-00171'])
@@ -3337,4 +3342,3 @@ class test_spicedb(unittest.TestCase):
 if __name__ == '__main__':
     unittest.main(verbosity=2)
 ################################################################################
-


### PR DESCRIPTION
With these changes, OOPS imports successfully with both Python 2 and 3 using the new pip-installed cspyce, and passes all `unittester.py` tests. I can't run the backplane tests because the current kernel set does not agree with what's required by the tests.