### PR TITLE
Change fpzip to rms-fpzip in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 astropy>=5.2
 coverage>=7.2.0
 cspyce>=2.0.7
-fpzip>=1.2
+rms-fpzip>=1.2
 numpy>=1.23.4
 pyparsing>=3.0.9
 scipy>=1.9.3


### PR DESCRIPTION
It's obvious that the `fpzip` library is not being regularly maintained, since it still doesn't work with Python 3.11 (which was released 6 months ago). To solve this problem, and prevent future issues, I have created an RMS fork of `fpzip`, currently here:

https://github.com/SETI/pds-fpzip

and visible on PyPI here:

https://pypi.org/project/rms-fpzip/

I have updated this version to handle Python 3.11 and changed/improved the way it packages its results and uploads them to PyPI. There is now a new `pip` installable package called `rms-fpzip` which has all the same functionality but supports Python 3.8 thru 3.11. 

hosts, oops, and polymath have been run in the nightly build using `rms-fpzip` with Python 3.8, 3.9, 3.10, and 3.11 with no failures.

To update your own environment:

```
pip uninstall fpzip
pip install rms-fpzip
```

I will note (as a broken record) this is an excellent reason to always use virtual environments, since you can use multiple versions of Python as well as multiple versions of packages in your testing.
