### PR TITLE
New method Observation.navigate

### DIFF
--- a/oops/observation/observation_.py
+++ b/oops/observation/observation_.py
@@ -376,7 +376,7 @@ class Observation(object):
             frame = self.frame
 
         # Copy and update the frame
-        obs = type(self).__new__()
+        obs = type(self).__new__(type(self))
         obs.__dict__ = self.__dict__.copy()
         obs.frame = Navigation(angles, reference=frame)
         return obs


### PR DESCRIPTION
This is a simple addition, avoiding some of the possible issues with `Fittable` that I am still working on. Sorry it took so long. Not fully tested but it looks right to me; we can iterate as needed.

`Obs.navigate(angles)` returns a new `Observation` that is a copy of the previous except that three rotation angles have been applied to the frame. You can create a new `Backplane` using the new `Observation` and the rotation angles will be applied. For purposes of determining a frame rotation, your angles would be `(0, 0, twist)`, where twist is the angle you want to apply. The first two entries are the offsets in `x` and `y`.

BTW it is really better to use a `Navigation` rather than an `OffsetFOV` for navigation. The difference is minor as long as the FOV has minimal distortion, but for wide-angle images, it could matter at the edge of the image where distortion is larger. What you are really doing is correcting the frame, not the pixels. I don't know how this will affect your work.

Furthermore, the `FOV` class is _defined_ to work with a coordinate grid in which X is horizontal and Y is vertical. For that reason, I have strong reservations against creating a "twisted" option for the `FOV` class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a non-mutating navigation operation to observations: apply rotational navigation using two or three angles (about Y, X, and optional Z). Returns a new observation with a rotated Navigation frame; the original observation is unchanged. If an observation already has a Navigation frame, the rotation composes relative to its underlying base frame.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->