### PR TITLE
Jiram cleanup like junocam

### DIFF
--- a/oops/hosts/juno/__init__.py
+++ b/oops/hosts/juno/__init__.py
@@ -77,6 +77,7 @@ class Juno(object):
         """
         if Juno.initialized: return
 
+        asof = kwargs.pop('asof', None)
         (ck, spk) = ('NONE', 'NONE')
 
         # Define some important paths and frames

--- a/oops/hosts/juno/jiram/__init__.py
+++ b/oops/hosts/juno/jiram/__init__.py
@@ -99,7 +99,7 @@ class JIRAM(object):
     @staticmethod
     def initialize(asof=None, **kwargs):
         """
-        Initialize key information about the JUNOCAM instrument; fill in key
+        Initialize key information about the JIRAM instrument; fill in key
         information about the WAC and NAC.
 
         Must be called first. After the first call, later calls to this function

--- a/oops/hosts/juno/jiram/__init__.py
+++ b/oops/hosts/juno/jiram/__init__.py
@@ -6,7 +6,6 @@ import numpy as np
 import julian
 import cspyce
 from polymath import *
-import os.path
 import pdsparser
 import oops
 
@@ -34,7 +33,7 @@ def from_file(filespec, return_all_planets=False, method='strict', **parameters)
     label = pdsparser.Pds3Label(filespec, method=method).as_dict()
 
     # Get common metadata
-    meta = Metadata(label)
+    meta = _Metadata(label)
 
     # Load time-dependent kernels
     Juno.load_cks(meta.tstart, meta.tstart + 3600.)
@@ -59,7 +58,7 @@ def from_file(filespec, return_all_planets=False, method='strict', **parameters)
 
 
 #*******************************************************************************
-class Metadata(object):
+class _Metadata(object):
 
     #===========================================================================
     def __init__(self, label):
@@ -97,37 +96,26 @@ class JIRAM(object):
 
     #===========================================================================
     @staticmethod
-    def initialize(ck='reconstructed', planets=None, asof=None,
-                   spk='reconstructed', gapfill=True,
-                   mst_pck=True, irregulars=True):
-        """Initialize key information about the JIRAM instrument.
+    def initialize(asof=None, **kwargs):
+        """
+        Initialize key information about the JUNOCAM instrument; fill in key
+        information about the WAC and NAC.
 
         Must be called first. After the first call, later calls to this function
         are ignored.
 
         Input:
-            ck,spk      'predicted', 'reconstructed', or 'none', depending on
-                        which kernels are to be used. Defaults are
-                        'reconstructed'. Use 'none' if the kernels are to be
-                        managed manually.
-            planets     A list of planets to pass to define_solar_system. None
-                        or 0 means all.
             asof        Only use SPICE kernels that existed before this date;
                         None to ignore.
-            gapfill     True to include gapfill CKs. False otherwise.
-            mst_pck     True to include MST PCKs, which update the rotation
-                        models for some of the small moons.
-            irregulars  True to include the irregular satellites;
-                        False otherwise.
+            kwargs:     Arguments for juno.initialize() and Body.define_solar_system()
         """
 
         # Quick exit after first call
-        if JIRAM.initialized: return
+        if JIRAM.initialized:
+            return
 
         # initialize Juno
-        Juno.initialize(ck=ck, planets=planets, asof=asof, spk=spk,
-                        gapfill=gapfill,
-                        mst_pck=mst_pck, irregulars=irregulars)
+        Juno.initialize(asof=asof, **kwargs)
         Juno.load_instruments(asof=asof)
 
         JIRAM.initialized = True

--- a/oops/hosts/juno/jiram/__init__.py
+++ b/oops/hosts/juno/jiram/__init__.py
@@ -28,8 +28,9 @@ def from_file(filespec, return_all_planets=False, method='strict', **parameters)
     JIRAM.initialize()    # Define everything the first time through; use
                           # defaults unless initialize() is called explicitly.
 
-    # Load the PDS label
     filespec = FCPath(filespec)
+
+    # Load the PDS label
     label = pdsparser.Pds3Label(filespec, method=method).as_dict()
 
     # Get common metadata

--- a/oops/hosts/juno/jiram/img.py
+++ b/oops/hosts/juno/jiram/img.py
@@ -6,7 +6,6 @@ import numpy as np
 import julian
 import cspyce
 from polymath import *
-import os.path
 import oops
 
 from oops.hosts.juno.jiram import JIRAM
@@ -41,7 +40,7 @@ def from_file(filespec, label, fast_distortion=True,
     filespec = FCPath(filespec)
 
     # Get metadata
-    meta = Metadata(label)
+    meta = _Metadata(label)
 
     # Define everything the first time through
     IMG.initialize(meta.tstart)
@@ -52,7 +51,7 @@ def from_file(filespec, label, fast_distortion=True,
     # Construct a Snapshot for each framelet
     obs = []
     for i in range(meta.nframelets):
-        fmeta = Metadata(flabels[i])
+        fmeta = _Metadata(flabels[i])
 
         item = oops.obs.Snapshot(('v','u'),
                                  fmeta.tstart, fmeta.exposure, fmeta.fov,
@@ -64,7 +63,7 @@ def from_file(filespec, label, fast_distortion=True,
 #        item.insert_subfield('spice_kernels', \
 #                   Juno.used_kernels(item.time, 'jiram', return_all_planets))
         item.insert_subfield('filespec', filespec)
-        item.insert_subfield('basename', os.path.basename(filespec))
+        item.insert_subfield('basename', filespec.name)
         obs.append(item)
 
     return obs
@@ -118,7 +117,7 @@ def _load_data(filespec, label, meta):
 
 
 #*******************************************************************************
-class Metadata(object):
+class _Metadata(object):
 
     #===========================================================================
     def __init__(self, label):
@@ -209,9 +208,7 @@ class IMG(object):
 
     #===========================================================================
     @staticmethod
-    def initialize(time, ck='reconstructed', planets=None, asof=None,
-                         spk='reconstructed', gapfill=True,
-                         mst_pck=True, irregulars=True):
+    def initialize(time, asof=None, **kwargs):
         """Initialize key information about the IMG instrument.
 
         Must be called first. After the first call, later calls to this function
@@ -220,27 +217,16 @@ class IMG(object):
         Input:
             time        time at which to define the inertialy fixed mirror-
                         corrected frame.
-            ck,spk      'predicted', 'reconstructed', or 'none', depending on which
-                        kernels are to be used. Defaults are 'reconstructed'. Use
-                        'none' if the kernels are to be managed manually.
-            planets     A list of planets to pass to define_solar_system. None or
-                        0 means all.
-            asof        Only use SPICE kernels that existed before this date; None
-                        to ignore.
-            gapfill     True to include gapfill CKs. False otherwise.
-            mst_pck     True to include MST PCKs, which update the rotation models
-                        for some of the small moons.
-            irregulars  True to include the irregular satellites;
-                        False otherwise.
+            asof        Only use SPICE kernels that existed before this date;
+                        None to ignore.
+            kwargs:     Arguments for juno.initialize() and Body.define_solar_system()
         """
 
         # Quick exit after first call
         if IMG.initialized: return
 
         # initialize JIRAM
-        JIRAM.initialize(ck=ck, planets=planets, asof=asof,
-                         spk=spk, gapfill=gapfill,
-                         mst_pck=mst_pck, irregulars=irregulars)
+        JIRAM.initialize(asof=asof, **kwargs)
 
         # Construct the SpiceFrames
         JIRAM.create_frame(time, 'I_MBAND')

--- a/oops/hosts/juno/jiram/img.py
+++ b/oops/hosts/juno/jiram/img.py
@@ -222,7 +222,8 @@ class IMG(object):
         """
 
         # Quick exit after first call
-        if IMG.initialized: return
+        if IMG.initialized:
+            return
 
         # initialize JIRAM
         JIRAM.initialize(asof=asof, **kwargs)

--- a/oops/hosts/juno/jiram/img.py
+++ b/oops/hosts/juno/jiram/img.py
@@ -84,7 +84,6 @@ def _load_data(filespec, label, meta):
     """
 
     # Read data
-    # seems like this should be handled in a readpds-style function somewhere
     local_path = filespec.retrieve()
     data = np.fromfile(local_path, dtype='<f4').reshape(meta.nlines,meta.nsamples)
 

--- a/oops/hosts/juno/jiram/spe.py
+++ b/oops/hosts/juno/jiram/spe.py
@@ -6,7 +6,6 @@ import numpy as np
 import julian
 import cspyce
 from polymath import *
-import os.path
 import oops
 
 from oops.hosts.juno.jiram import JIRAM
@@ -40,7 +39,7 @@ def from_file(filespec, label, fast_distortion=True,
     filespec = FCPath(filespec)
 
     # Get metadata
-    meta = Metadata(label)
+    meta = _Metadata(label)
 
     # Define everything the first time through
     SPE.initialize(meta.tstart)
@@ -59,7 +58,7 @@ def from_file(filespec, label, fast_distortion=True,
 #        item.insert_subfield('spice_kernels',
 #                   Juno.used_kernels(item.time, 'jiram', return_all_planets))
         item.insert_subfield('filespec', filespec)
-        item.insert_subfield('basename', os.path.basename(filespec))
+        item.insert_subfield('basename', filespec.name)
         slits.append(item)
 
 #    return slits
@@ -72,7 +71,7 @@ def from_file(filespec, label, fast_distortion=True,
 #    obs.insert_subfield('spice_kernels',
 #               Juno.used_kernels(item.time, 'jiram', return_all_planets))
     obs.insert_subfield('filespec', filespec)
-    obs.insert_subfield('basename', os.path.basename(filespec))
+    obs.insert_subfield('basename', filespec.name)
 
     return (obs, slits)
 
@@ -100,7 +99,7 @@ def _load_data(filespec, label, meta):
 
 
 #*******************************************************************************
-class Metadata(object):
+class _Metadata(object):
 
     #===========================================================================
     def __init__(self, label):
@@ -155,9 +154,7 @@ class SPE(object):
 
     #===========================================================================
     @staticmethod
-    def initialize(time, ck='reconstructed', planets=None, asof=None,
-                         spk='reconstructed', gapfill=True,
-                         mst_pck=True, irregulars=True):
+    def initialize(time, asof=None, **kwargs):
         """
         Initialize key information about the SPE instrument.
 
@@ -167,27 +164,17 @@ class SPE(object):
         Input:
             time        time at which to define the inertialy fixed mirror-
                         corrected frame.
-            ck,spk      'predicted', 'reconstructed', or 'none', depending on which
-                        kernels are to be used. Defaults are 'reconstructed'. Use
-                        'none' if the kernels are to be managed manually.
-            planets     A list of planets to pass to define_solar_system. None or
-                        0 means all.
-            asof        Only use SPICE kernels that existed before this date; None
-                        to ignore.
-            gapfill     True to include gapfill CKs. False otherwise.
-            mst_pck     True to include MST PCKs, which update the rotation models
-                        for some of the small moons.
-            irregulars  True to include the irregular satellites;
-                        False otherwise.
+            asof        Only use SPICE kernels that existed before this date;
+                        None to ignore.
+            kwargs:     Arguments for juno.initialize() and Body.define_solar_system()
         """
 
         # Quick exit after first call
-        if SPE.initialized: return
+        if SPE.initialized:
+            return
 
         # initialize JIRAM
-        JIRAM.initialize(ck=ck, planets=planets, asof=asof,
-                        spk=spk, gapfill=gapfill,
-                        mst_pck=mst_pck, irregulars=irregulars)
+        JIRAM.initialize(asof=asof, **kwargs)
 
         # Construct the SpiceFrame
         JIRAM.create_frame(time, 'S')

--- a/oops/hosts/juno/jiram/spe.py
+++ b/oops/hosts/juno/jiram/spe.py
@@ -84,14 +84,12 @@ def _load_data(filespec, label, meta):
         label           Label for composite image.
         meta            Image Metadata object.
 
-    Return:             (framelets, framelet_labels)
-        framelets       A Numpy array containing the individual frames in
-                        axis order (line, sample, framelet #).
-        framelet_labels List of labels for each framelet.
+    Return:             (spectra)
+        spectra         A Numpy array containing the individual spectra in
+                        wavelength order (spectrum #, sample).
     """
 
     # Read data
-    # seems like this should be handled in a readpds-style function somewhere
     local_path = filespec.retrieve()
     data = np.fromfile(local_path, dtype='<f4').reshape(meta.nlines,meta.nsamples)
 

--- a/oops/hosts/juno/junocam/__init__.py
+++ b/oops/hosts/juno/junocam/__init__.py
@@ -273,7 +273,7 @@ class _Metadata(object):
         match = RATIONALE_RE.match(label['RATIONALE_DESC'])
         if match:
             return float(match.group(1))
-        return 0
+        return cy
 
 #*******************************************************************************
 class JUNOCAM(object):
@@ -300,7 +300,8 @@ class JUNOCAM(object):
         """
 
         # Quick exit after first call
-        if JUNOCAM.initialized: return
+        if JUNOCAM.initialized:
+            return
 
         # Initialize Juno
         Juno.initialize(asof=asof, **kwargs)

--- a/oops/hosts/juno/junocam/__init__.py
+++ b/oops/hosts/juno/junocam/__init__.py
@@ -120,7 +120,7 @@ def _load_data(filespec, label, meta):
 
     # Read data
     bits = label['IMAGE']['SAMPLE_BITS']
-    dtype = '>u' + str(int(bits//8))
+    dtype = '>u' + str(int(bits // 8))
     local_path = filespec.retrieve()
     data = np.fromfile(local_path, dtype=dtype).reshape(meta.nlines, meta.nsamples)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Juno initialization so time-based kernel selection consistently uses the provided `asof`.
  * Refined JIRAM, IMG, and SPE ingestion to use cleaner, stable filenames in generated records.
  * Corrected JUNOCAM methane correction so values remain unchanged when no rationale match is found.

* **API Updates**
  * Simplified IMG/SPE/JIRAM initialization interfaces to accept `asof` directly and forward remaining configuration via keyword arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->