### PR TITLE
One-line change to use new Qube.add_attr() in method in Backplane

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,10 +19,6 @@ jobs:
         # MacOS: Python 3.8-3.10 does not currently work on MacOS.
         include:
           - os: self-hosted-linux
-            python-version: "3.9"
-          - os: self-hosted-linux
-            python-version: "3.10"
-          - os: self-hosted-linux
             python-version: "3.11"
           - os: self-hosted-linux
             python-version: "3.12"

--- a/oops/backplane/__init__.py
+++ b/oops/backplane/__init__.py
@@ -899,7 +899,10 @@ class Backplane(object):
 
         # For reference, we add the key as an attribute of each backplane
         # object
-        backplane.key = key
+        if hasattr(backplane, 'add_attr'):      # temporary!
+            backplane.add_attr('key', key)
+        else:
+            backplane.key = key                 # needed for old polymath
         backplane = backplane.as_readonly(recursive=True)
         self.backplanes[key] = backplane.wod
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "rms-oops"
 dynamic = ["version"]
 description = "Object-Oriented Python and SPICE"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 
 dependencies = [
   "astropy",
@@ -42,9 +42,6 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
   "Topic :: Utilities",
   "License :: OSI Approved :: Apache Software License",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
# for-new-polymath

This is a very short update to `backplane/__init__.py` for the new polymath method `add_attr`, which ensures that the "key" attribute added by Backplane is preserved. It is also written to be backward compatible with the existing version of polymath. I have tested it by hand and it passes the GitHub tests. I _hope_ it will work with image navigation.

Also made Python 3.11 the minimum supported version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when registering backplanes across supported object versions.
  * Ensured the backplane key is consistently stored during registration.

* **Chores**
  * Updated the minimum supported Python version to 3.11. Python 3.8–3.10 are no longer supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->